### PR TITLE
Add c-success token when value is zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `c-success` token to component when the received value is zero.
+
 ## [0.2.0] - 2019-09-19
 
-## Added
+### Added
 
 - Show TBA in case of undefined or null price.
 
 ## [0.1.0] - 2019-08-28
 
-## Added
+### Added
 
 - initial setup
 

--- a/react/FormattedPrice.tsx
+++ b/react/FormattedPrice.tsx
@@ -1,4 +1,4 @@
-import React, { FC, Fragment } from 'react'
+import React, { FC } from 'react'
 import { injectIntl, InjectedIntlProps, FormattedMessage } from 'react-intl'
 import { FormattedCurrency } from 'vtex.format-currency'
 
@@ -6,7 +6,7 @@ const FormattedPrice: FC<FormattedPriceProps & InjectedIntlProps> = ({
   value,
 }) => {
   return (
-    <Fragment>
+    <div className={value === 0 ? 'c-success' : ''}>
       {value === 0 ? (
         <FormattedMessage id="store/price.Free" />
       ) : value === null || value === undefined ? (
@@ -14,7 +14,7 @@ const FormattedPrice: FC<FormattedPriceProps & InjectedIntlProps> = ({
       ) : (
         <FormattedCurrency value={value} />
       )}
-    </Fragment>
+    </div>
   )
 }
 


### PR DESCRIPTION
#### What problem is this solving?

Everywhere we're using this component we're adding the `c-success` component to make the "FREE" text green. It's probably better to move this logic inside the component.

#### How should this be manually tested?

Use [this workspace](https://free--vtexgame1.myvtex.com), add any item and go to `/cart`. Apply the `testegratis` coupon and verify the product-list shows the item price as "FREE" in green text.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/23493/ajustes-nos-itens-da-lista-de-produtos-em-caso-de-valor-zerado).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
